### PR TITLE
single header include and compile flag for http

### DIFF
--- a/examples/http_client.cpp
+++ b/examples/http_client.cpp
@@ -1,6 +1,6 @@
+#define NETLIB_USE_HTTP
+
 #include "../src/netlib.hpp"
-#include "../src/http/client.hpp"
-#include "../src/http/http.hpp"
 #include <csignal>
 #include <iomanip>
 #include <iostream>

--- a/src/netlib.hpp
+++ b/src/netlib.hpp
@@ -3,3 +3,7 @@
 #include "client.hpp"
 #include "server.hpp"
 #include "thread_pool.hpp"
+
+#ifdef NETLIB_USE_HTTP
+#include "http/client.hpp"
+#endif


### PR DESCRIPTION
the example http_client.cpp shows to include the headers in following order:

```
#define "../src/netlib.hpp"
#define  "../src/http/client.hpp"
#define "../src/http/http.hpp"
```

However, a common setting in auto-formatters like clang-format will sort the headers in alphabetical order (which is also a requirement in some code-styles), like this:

```
#define  "../src/http/client.hpp"
#define "../src/http/http.hpp"
#define "../src/netlib.hpp"
```

But this will lead to compilation errors as `netlib.hpp` includes headers that are needed by `client.hpp`, for example  `<future>` but also library-defined symbols like `DEFAULT_TIMEOUT` or `TICK_TIME`, which are then included or defined after `client.hpp` needs them.

The ordering of includes of all needed library-headers should not matter, but a single header file to include everything would be preferable anyway. To exclude features like HTTP by default anyway, a compile switch is added.